### PR TITLE
Mention that ENCRYPTION_KEY must be 32 bytes

### DIFF
--- a/content/setup/installation.md
+++ b/content/setup/installation.md
@@ -37,6 +37,8 @@ volumes:
   arcane-data:
 ```
 
+where ENCRYPTION_KEY must be 32 bytes (raw/base64/hex).
+
 ## 2. Review Volumes & Imports:
 
 **_/var/run/docker.sock_**: Lets Arcane manage Docker.


### PR DESCRIPTION
I got that info from the crash log of the container, it would be convenient to know right away.