### PR TITLE
docs: add documentations for v1.19.0

### DIFF
--- a/content/cli/install.md
+++ b/content/cli/install.md
@@ -39,6 +39,46 @@ You can also install the CLI with our helper script. Pick the command that match
 > [!NOTE]
 > `--beta` always installs the latest `cli-next` binary from R2. It does not use a versioned beta release path.
 
+### APT (Debian / Ubuntu)
+
+Add the signing key:
+
+<Snippet text="curl -fsSL https://pkgs.getarcane.app/repository/raw/arcane-repo-signing.asc | sudo gpg --dearmor -o /usr/share/keyrings/arcane-archive-keyring.gpg" class="mt-2" />
+
+Add the repository:
+
+```bash
+sudo tee /etc/apt/sources.list.d/arcane.sources << 'EOF'
+Types: deb
+URIs: https://pkgs.getarcane.app/repository/debian/
+Suites: stable
+Components: main
+Signed-By: /usr/share/keyrings/arcane-archive-keyring.gpg
+EOF
+```
+
+Install:
+
+<Snippet text="sudo apt update && sudo apt install arcane-cli" class="mt-2" />
+
+### YUM / DNF (RHEL, Fedora, CentOS)
+
+Add the repository:
+
+```bash
+sudo tee /etc/yum.repos.d/arcane.repo << 'EOF'
+[arcane]
+name=Arcane Repository
+baseurl=https://pkgs.getarcane.app/repository/yum/$basearch/
+enabled=1
+gpgcheck=0
+EOF
+```
+
+Install:
+
+<Snippet text="sudo dnf install arcane-cli" class="mt-2" />
+
 ### Homebrew
 
 <Snippet text="brew install getarcaneapp/tap/arcane-cli" class="mt-2" />

--- a/content/security/edge-mtls.md
+++ b/content/security/edge-mtls.md
@@ -1,0 +1,168 @@
+---
+title: "Edge Agent mTLS"
+description: "Add mutual TLS authentication between the Arcane Manager and its edge agents."
+order: 2
+---
+
+<script lang="ts">
+import { Snippet } from '$lib/components/ui/snippet/index.js';
+import { Link } from '$lib/components/ui/link/index.js';
+</script>
+
+Edge agents connect outbound to the Arcane Manager over HTTPS. By default they authenticate with an agent token. Enabling mTLS adds a second factor: the Manager issues each agent a client certificate, and the TLS handshake proves the agent holds the matching private key. Certificates are much harder to leak than tokens - they never appear in logs, environment variables, or API responses.
+
+> [!NOTE]
+> See <Link href="/docs/features/environments">Remote Environments</Link> for how edge agents are created and connected. mTLS is a layer on top of that flow.
+
+## What it does
+
+With mTLS enabled:
+
+- The agent token still bootstraps the first enrollment.
+- When Arcane terminates mTLS directly, the client certificate authenticates every request after that, and the Manager checks its SPIFFE URI SAN against the environment resolved from the agent token.
+- When mTLS is terminated by a reverse proxy, the proxy enforces client certificate authentication before forwarding edge tunnel traffic to Arcane. Arcane still uses the agent token to resolve the environment.
+- Traffic is rejected if the certificate is missing, invalid, or belongs to a different environment at the layer responsible for terminating mTLS.
+
+## Quick start
+
+Arcane can generate all required agent certificates for you. You only need to:
+
+1. Serve the Manager behind HTTPS so agents can verify the Manager.
+2. Set `EDGE_MTLS_MODE=required` on both sides.
+3. Provide the agent with an `AGENT_TOKEN` from the environment you want to manage.
+
+No cert/key files need to exist on disk up front. Arcane will:
+
+- Generate its own edge CA on first Manager start.
+- Issue an agent certificate automatically the first time an agent enrolls.
+- Re-use existing certificates on subsequent starts until they are expired or near expiry.
+
+### Manager
+
+If Arcane terminates HTTPS directly, serve HTTPS using any valid cert (self-signed, Let's Encrypt, etc.):
+
+<Snippet text="TLS_ENABLED=true" class="mt-2 mb-2 w-full" />
+<Snippet text="TLS_CERT_FILE=/etc/arcane/tls.crt" class="mt-2 mb-2 w-full" />
+<Snippet text="TLS_KEY_FILE=/etc/arcane/tls.key" class="mt-2 mb-2 w-full" />
+
+If a reverse proxy terminates HTTPS and mTLS, Arcane can receive proxied HTTP from that trusted proxy. In that setup, configure mTLS enforcement on the proxy for the edge tunnel routes.
+
+Then enable edge mTLS:
+
+<Snippet text="EDGE_MTLS_MODE=required" class="mt-2 mb-2 w-full" />
+<Snippet text="EDGE_MTLS_ASSETS_DIR=/app/data/edge-mtls" class="mt-2 mb-2 w-full" />
+
+`EDGE_MTLS_ASSETS_DIR` is where Arcane stores the CA and issued certs. With no `EDGE_MTLS_CA_FILE` set, Arcane generates the edge CA into `EDGE_MTLS_ASSETS_DIR/ca.crt` and `ca.key` - the private key is encrypted at rest with your `ENCRYPTION_KEY`.
+
+> [!NOTE]
+> See <Link href="/docs/configuration/tls">TLS and HTTP/2</Link> if you want Arcane itself to terminate HTTPS, or terminate at a reverse proxy in front of it.
+
+### Agent
+
+<Snippet text="EDGE_AGENT=true" class="mt-2 mb-2 w-full" />
+<Snippet text="MANAGER_API_URL=https://manager.example.com" class="mt-2 mb-2 w-full" />
+<Snippet text="AGENT_TOKEN=arc_xxxxxxxxxxxxxxxx" class="mt-2 mb-2 w-full" />
+<Snippet text="EDGE_MTLS_MODE=required" class="mt-2 mb-2 w-full" />
+<Snippet text="EDGE_MTLS_ASSETS_DIR=/app/data/edge-mtls-agent" class="mt-2 mb-2 w-full" />
+<Snippet text="EDGE_MTLS_CA_FILE=/etc/ssl/manager-ca.crt" class="mt-2 mb-2 w-full" />
+
+`MANAGER_API_URL` must use `https://`. `EDGE_MTLS_CA_FILE` is the trust root for the Manager's HTTPS certificate.
+
+On first start:
+
+1. The agent calls `POST /api/tunnel/mtls/enroll` over plain HTTPS, presenting only the `AGENT_TOKEN`.
+2. The Manager issues a client certificate (valid ~1 year) and returns it along with the edge CA.
+3. The agent writes them atomically into `EDGE_MTLS_ASSETS_DIR` as `agent.crt`, `agent.key`, and `ca.crt`, records enrollment completion, and reconnects using them.
+
+On subsequent starts, the agent reuses valid assets on disk. If the local certificate is expired or inside the renewal window, it enrolls again.
+
+## Modes
+
+`EDGE_MTLS_MODE` accepts:
+
+| Value      | Behavior                                                                                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `disabled` | No mTLS. Token-only auth. Default when the env var is not set.                                                                                                           |
+| `optional` | Manager accepts both mTLS and token-only connections.                                                                                                                    |
+| `required` | Direct Arcane TLS requires a valid client certificate. Proxy-terminated deployments must enforce client certificates at the proxy before forwarding edge tunnel traffic. |
+
+> [!TIP]
+> Use `optional` while rolling mTLS out across existing agents, then switch to `required` once all agents are enrolled.
+
+## Using your own certificates
+
+If you already have a PKI and want Arcane to use it instead of generating one, set the explicit paths - they always take precedence over auto-generation.
+
+Manager:
+
+<Snippet text="EDGE_MTLS_MODE=required" class="mt-2 mb-2 w-full" />
+<Snippet text="EDGE_MTLS_CA_FILE=/etc/arcane/edge-ca.crt" class="mt-2 mb-2 w-full" />
+
+Arcane still signs new agent certs using its own internal key unless you also pre-provision agent certs out-of-band.
+
+Agent:
+
+<Snippet text="EDGE_MTLS_MODE=required" class="mt-2 mb-2 w-full" />
+<Snippet text="EDGE_MTLS_CERT_FILE=/etc/arcane/agent.crt" class="mt-2 mb-2 w-full" />
+<Snippet text="EDGE_MTLS_KEY_FILE=/etc/arcane/agent.key" class="mt-2 mb-2 w-full" />
+<Snippet text="EDGE_MTLS_CA_FILE=/etc/arcane/manager-ca.crt" class="mt-2 mb-2 w-full" />
+
+When `EDGE_MTLS_CERT_FILE` and `EDGE_MTLS_KEY_FILE` are both set, the agent skips enrollment entirely.
+
+## Downloading certificates from the UI
+
+After you create an edge environment, the **New environment** sheet and the environment detail page expose the generated assets:
+
+- `ca.crt` (public) - inline in the deployment snippet and downloadable by any authenticated user.
+- `agent.crt` (public) - same.
+- `agent.key` (private) - **not** returned inline. Use the **Download certificate** link, which hits an admin-only endpoint. This prevents the private key from landing in browser history, logs, or the query cache.
+
+Bulk download (`.zip` of all three files) is also admin-only.
+
+Every download emits an `environment.mtls.download` audit event with the admin's username, filename, and whether the file is sensitive.
+
+## Local development
+
+The repo ships helper recipes for running a local Manager and agent over HTTPS.
+
+Generate a self-signed cert for the local Manager's HTTPS listener (covers `localhost`, `127.0.0.1`, `::1`, `arcane-local`):
+
+<Snippet text="just dev-tls" class="mt-2 mb-2 w-full" />
+<Snippet text="just dev-tls force=true" class="mt-2 mb-2 w-full" />
+
+The first writes `backend/local-manager.{crt,key}`; the second regenerates them.
+
+Start the backend with HTTPS enabled:
+
+<Snippet text="TLS_ENABLED=true TLS_CERT_FILE=./backend/local-manager.crt TLS_KEY_FILE=./backend/local-manager.key just dev backend" class="mt-2 mb-2 w-full" />
+
+Start a local edge agent. It auto-enrolls against the Manager and pins `./backend/local-manager.crt` as the trust root:
+
+<Snippet text="AGENT_TOKEN=<edge-environment-token> just dev agent" class="mt-2 mb-2 w-full" />
+
+Agent state (issued cert, key, CA) lives in `.tmp/edge-test-agent/edge-mtls-agent/`. Delete that directory to force a re-enrollment.
+
+## Troubleshooting
+
+**Agent enrollment fails when `EDGE_MTLS_MODE=required` is set.**
+If `EDGE_MTLS_CERT_FILE` and `EDGE_MTLS_KEY_FILE` are unset, the agent enrolls
+with the manager automatically. Check that `MANAGER_API_URL` is `https://`, the
+agent token is valid, and the manager has mTLS enabled.
+
+**Agent fails with `EDGE_MTLS_MODE requires MANAGER_API_URL to use https`.**
+The agent refuses to enroll or connect over plain HTTP. Put the Manager behind HTTPS.
+
+**Agent fails with `x509: certificate signed by unknown authority` when talking to the Manager.**
+`EDGE_MTLS_CA_FILE` on the agent is the trust root for the Manager's HTTPS certificate. If you're using a self-signed Manager cert, point `EDGE_MTLS_CA_FILE` at it. If you're using a public CA (Let's Encrypt, etc.), you can leave `EDGE_MTLS_CA_FILE` unset and Arcane will fall back to the system trust store.
+
+**Manager logs `tunnel request failed: unsupported edge command ...`.**
+The route the UI is calling doesn't have a command mapping registered on the edge tunnel. File a bug including the HTTP method and path from the error.
+
+**Agent repeatedly re-enrolls on every restart.**
+`EDGE_MTLS_ASSETS_DIR` isn't persistent. Mount it on a volume so `agent.crt` and `agent.key` survive restarts.
+
+## Rotation and revocation
+
+- Agent certificates are valid for ~1 year.
+- Agents re-enroll automatically when the local certificate is expired or close to expiry. Manually delete `agent.crt` and `agent.key` on the agent and restart to force re-enrollment immediately.
+- There is no CRL / OCSP. To disable an agent, delete or regenerate its environment API key in the UI.

--- a/src/lib/config/docs.ts
+++ b/src/lib/config/docs.ts
@@ -81,7 +81,11 @@ const GET_STARTED = group('Get Started', [
 	leaf('setup/next-images')
 ]);
 
-const SECURITY = group('Security', [leaf('security/verify-artifacts'), leaf('setup/socket-proxy')]);
+const SECURITY = group('Security', [
+	leaf('security/verify-artifacts'),
+	leaf('setup/socket-proxy'),
+	leaf('security/edge-mtls')
+]);
 
 const CONFIGURATION = group('Configuration', [
 	leaf('configuration/environment'),


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds v1.19.0 documentation: new APT and YUM/DNF installation sections for the CLI, a full mTLS edge-agent guide (`security/edge-mtls.md`), and the corresponding nav entry in `docs.ts`.

- The mTLS doc is thorough, covering quick-start, modes, custom PKI, UI certificate downloads, local dev, troubleshooting, and rotation/revocation.
- The YUM/DNF repo snippet ships with `gpgcheck=0`, which disables GPG package signature verification; the APT section correctly wires up a keyring and `Signed-By`, so parity is expected here.
- `src/lib/config/docs.ts` correctly adds the new page to the Security navigation group.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The mTLS documentation and nav change are safe; the YUM/DNF install snippet actively instructs users to disable package signature verification, which needs to be corrected before the page goes live.

The new mTLS guide and nav entry are well-written and pose no correctness concerns. However, the YUM/DNF repo snippet ships `gpgcheck=0` — unlike the APT section, which properly configures a signing key — meaning every RPM-based user who follows this guide will install the CLI without any package integrity check. Fixing this before publication is important given this is a security product's documentation.

content/cli/install.md — the YUM/DNF repo block needs GPG verification enabled before the page is published.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Package integrity bypass** (`content/cli/install.md`): The YUM/DNF repository configuration disables GPG signature verification for installed packages. The APT section correctly uses a keyring and `Signed-By`; the RPM section should match it by enabling signature checking and pointing to the signing key already hosted on `pkgs.getarcane.app`.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Fwebsite%22%20on%20the%20existing%20branch%20%22docs%2Fv1.19.0%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fv1.19.0%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acontent%2Fcli%2Finstall.md%3A69-75%0AThe%20YUM%2FDNF%20repo%20config%20disables%20GPG%20package%20verification%20with%20%60gpgcheck%3D0%60%2C%20while%20the%20APT%20section%20correctly%20sets%20up%20signature%20checking%20with%20a%20keyring.%20Any%20user%20who%20follows%20these%20instructions%20on%20RHEL%2FFedora%2FCentOS%20will%20install%20packages%20without%20verifying%20their%20authenticity%2C%20leaving%20them%20open%20to%20tampered%20packages%20from%20a%20MITM%20or%20a%20compromised%20mirror.%20The%20signing%20key%20URL%20is%20already%20served%20from%20%60pkgs.getarcane.app%60%2C%20so%20it%20can%20simply%20be%20referenced%20here.%0A%0A%60%60%60suggestion%0Asudo%20tee%20%2Fetc%2Fyum.repos.d%2Farcane.repo%20%3C%3C%20'EOF'%0A%5Barcane%5D%0Aname%3DArcane%20Repository%0Abaseurl%3Dhttps%3A%2F%2Fpkgs.getarcane.app%2Frepository%2Fyum%2F%24basearch%2F%0Aenabled%3D1%0Agpgcheck%3D1%0Agpgkey%3Dhttps%3A%2F%2Fpkgs.getarcane.app%2Frepository%2Fraw%2Farcane-repo-signing.asc%0AEOF%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acontent%2Fcli%2Finstall.md%3A69-75%0AThe%20YUM%2FDNF%20repo%20config%20disables%20GPG%20package%20verification%20with%20%60gpgcheck%3D0%60%2C%20while%20the%20APT%20section%20correctly%20sets%20up%20signature%20checking%20with%20a%20keyring.%20Any%20user%20who%20follows%20these%20instructions%20on%20RHEL%2FFedora%2FCentOS%20will%20install%20packages%20without%20verifying%20their%20authenticity%2C%20leaving%20them%20open%20to%20tampered%20packages%20from%20a%20MITM%20or%20a%20compromised%20mirror.%20The%20signing%20key%20URL%20is%20already%20served%20from%20%60pkgs.getarcane.app%60%2C%20so%20it%20can%20simply%20be%20referenced%20here.%0A%0A%60%60%60suggestion%0Asudo%20tee%20%2Fetc%2Fyum.repos.d%2Farcane.repo%20%3C%3C%20'EOF'%0A%5Barcane%5D%0Aname%3DArcane%20Repository%0Abaseurl%3Dhttps%3A%2F%2Fpkgs.getarcane.app%2Frepository%2Fyum%2F%24basearch%2F%0Aenabled%3D1%0Agpgcheck%3D1%0Agpgkey%3Dhttps%3A%2F%2Fpkgs.getarcane.app%2Frepository%2Fraw%2Farcane-repo-signing.asc%0AEOF%0A%60%60%60%0A%0A&repo=getarcaneapp%2Fwebsite&pr=380&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/cli/install.md:69-75
The YUM/DNF repo config disables GPG package verification with `gpgcheck=0`, while the APT section correctly sets up signature checking with a keyring. Any user who follows these instructions on RHEL/Fedora/CentOS will install packages without verifying their authenticity, leaving them open to tampered packages from a MITM or a compromised mirror. The signing key URL is already served from `pkgs.getarcane.app`, so it can simply be referenced here.

```suggestion
sudo tee /etc/yum.repos.d/arcane.repo << 'EOF'
[arcane]
name=Arcane Repository
baseurl=https://pkgs.getarcane.app/repository/yum/$basearch/
enabled=1
gpgcheck=1
gpgkey=https://pkgs.getarcane.app/repository/raw/arcane-repo-signing.asc
EOF
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add documentations for v1.19.0"](https://github.com/getarcaneapp/website/commit/94b01be9a4671bca501818ce67089c9769aad2ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31638395)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->