### PR TITLE
fix: Typo Bash Command Snippet in `config.md`

### DIFF
--- a/content/cli/config.md
+++ b/content/cli/config.md
@@ -82,7 +82,7 @@ A quick first run looks like this:
 
 <Snippet text="arcane-cli config set server-url http://localhost:3552" class="mt-2" />
 
-<Snippet text="arcane-cli config set apt-key arc_xxxxxxx" class="mt-2" />
+<Snippet text="arcane-cli config set api-key arc_xxxxxxx" class="mt-2" />
 
 ## Authenticate
 


### PR DESCRIPTION
Now we can copy/paste the command properly.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a typo in `content/cli/config.md`, correcting `apt-key` to `api-key` in the "Getting Started" bash command snippet. The fix makes the snippet copyable and consistent with the identical command that already appeared correctly in the "Authenticate" section.

- The corrected snippet (`arcane-cli config set api-key arc_xxxxxxx`) now matches the command shown later in the same file under "Option B: API key".
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-character documentation typo fix with no logic or runtime impact.

One word corrected in a markdown documentation file; the rest of the file is untouched and the fix aligns the snippet with the already-correct usage later in the same document.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Typo Bash Command Snippet in \`config..."](https://github.com/getarcaneapp/website/commit/acde06200d656dcf24af0071a20c5add4d9404fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30869834)</sub>

<!-- /greptile_comment -->