### PR TITLE
docs: add dhi image docs

### DIFF
--- a/content/configuration/environment.md
+++ b/content/configuration/environment.md
@@ -31,6 +31,12 @@ Replace each placeholder with the real value from your database.
 - `<postgres_port>`: the port Postgres uses
 - `<postgres_db_name>`: the database name to connect to
 
+## Container runtime user
+
+Official Arcane images set `ARCANE_DEFAULT_NONROOT=true`, so the process drops to the built-in non-root user (`65532:65532`) when `PUID` and `PGID` are not set.
+
+Use `PUID` and `PGID` if mounted files should be owned by a specific host user and group. If you use a custom Unix Docker socket with `DOCKER_HOST`, Arcane uses that socket path when adding the runtime user to the socket group.
+
 ## Environment Variables
 
 <EnvTable />

--- a/content/guides/gpu-setup.md
+++ b/content/guides/gpu-setup.md
@@ -5,7 +5,9 @@ order: 3
 ---
 
 > [!IMPORTANT]
-> This guide assumes GPU drivers are already installed and configured on your host system. Refer to the respective vendor documentation for driver installation. 
+> This guide assumes GPU drivers are already installed and configured on your host system. Refer to the respective vendor documentation for driver installation.
+>
+> Official Arcane images use a minimal hardened runtime base and do not bundle vendor GPU utilities. NVIDIA monitoring relies on `nvidia-smi` being injected by the NVIDIA container runtime. AMD monitoring reads `/sys/class/drm` directly. Intel monitoring requires an image/runtime that provides `intel_gpu_top`.
 
 ## NVIDIA GPU Setup
 

--- a/content/setup/installation.md
+++ b/content/setup/installation.md
@@ -65,6 +65,9 @@ volumes:
 
 ## 2. Understand the folders Arcane uses:
 
+> [!NOTE]
+> Official Arcane manager and agent images start as root only for startup preparation, then drop to a non-root runtime user by default. Set `PUID` and `PGID` when you want Arcane-created files to use a specific host UID/GID. If you omit them, Arcane uses its built-in non-root user (`65532:65532`).
+
 **_/var/run/docker.sock_**: Gives Arcane access to Docker.
 
 **_arcane-data_**: Arcane's data folder, which stores things like the database and project data.

--- a/content/setup/next-images.md
+++ b/content/setup/next-images.md
@@ -19,11 +19,11 @@ Arcane provides "next" builds that contain the latest features and improvements 
 
 ## Docker Images
 
-Each Image has 3 variants, `next`, `next-static`, and `next-distroless`.
+Each image has 3 variants: `next`, `next-static`, and `next-distroless`.
 
-Both the `next` (based on alpine) and the `next-distroless` (based on distroless-static) are built with static binaries. These builds may not contain the required functionality for some external monitoring tools like GPU's etc.
+The normal `next` tag uses Arcane's hardened Debian-based runtime image and is the fully featured preview build for the manager and agent.
 
-The normal `next` tag is the fully complete build of Arcane and the Agent, all features should be available.
+The `next-static` and `next-distroless` variants use static binaries and smaller runtime images. They are useful for minimal deployments, but they may not include host-provided tooling or shared-library behavior needed by some integrations.
 
 ### Arcane Manager (Next)
 

--- a/static/config.json
+++ b/static/config.json
@@ -9,9 +9,7 @@
       "env": "ADMIN_STATIC_API_KEY",
       "field": "AdminStaticAPIKey",
       "type": "string",
-      "options": [
-        "file"
-      ],
+      "options": ["file"],
       "supportsFile": true,
       "source": "config.Config",
       "sourceFile": "backend/internal/config/config.go",
@@ -30,9 +28,7 @@
       "env": "AGENT_TOKEN",
       "field": "AgentToken",
       "type": "string",
-      "options": [
-        "file"
-      ],
+      "options": ["file"],
       "supportsFile": true,
       "source": "config.Config",
       "sourceFile": "backend/internal/config/config.go",
@@ -79,14 +75,10 @@
       "field": "AutoLoginPassword",
       "type": "string",
       "defaultValue": "arcane-admin",
-      "options": [
-        "file"
-      ],
+      "options": ["file"],
       "supportsFile": true,
       "conditional": true,
-      "buildTags": [
-        "buildables"
-      ],
+      "buildTags": ["buildables"],
       "source": "config.BuildablesConfig",
       "sourceFile": "backend/internal/config/buildables_config.go",
       "sourceSymbol": "config.BuildablesConfig.AutoLoginPassword"
@@ -98,9 +90,7 @@
       "defaultValue": "arcane",
       "description": "Auto-login credentials (used only when built with the buildables tag + autologin feature flag).",
       "conditional": true,
-      "buildTags": [
-        "buildables"
-      ],
+      "buildTags": ["buildables"],
       "source": "config.BuildablesConfig",
       "sourceFile": "backend/internal/config/buildables_config.go",
       "sourceSymbol": "config.BuildablesConfig.AutoLoginUsername"
@@ -110,9 +100,7 @@
       "field": "DatabaseURL",
       "type": "string",
       "defaultValue": "file:data/arcane.db?_pragma=journal_mode(WAL)\u0026_pragma=busy_timeout(2500)\u0026_txlock=immediate",
-      "options": [
-        "file"
-      ],
+      "options": ["file"],
       "supportsFile": true,
       "source": "config.Config",
       "sourceFile": "backend/internal/config/config.go",
@@ -208,9 +196,7 @@
       "field": "EdgeMTLSMode",
       "type": "string",
       "defaultValue": "disabled",
-      "options": [
-        "toLower"
-      ],
+      "options": ["toLower"],
       "source": "config.Config",
       "sourceFile": "backend/internal/config/config.go",
       "sourceSymbol": "config.Config.EdgeMTLSMode"
@@ -238,9 +224,7 @@
       "field": "EdgeTransport",
       "type": "string",
       "defaultValue": "auto",
-      "options": [
-        "toLower"
-      ],
+      "options": ["toLower"],
       "source": "config.Config",
       "sourceFile": "backend/internal/config/config.go",
       "sourceSymbol": "config.Config.EdgeTransport"
@@ -250,9 +234,7 @@
       "field": "EncryptionKey",
       "type": "string",
       "defaultValue": "arcane-dev-key-32-characters!!!",
-      "options": [
-        "file"
-      ],
+      "options": ["file"],
       "supportsFile": true,
       "source": "config.Config",
       "sourceFile": "backend/internal/config/config.go",
@@ -335,9 +317,7 @@
       "field": "JWTSecret",
       "type": "string",
       "defaultValue": "default-jwt-secret-change-me",
-      "options": [
-        "file"
-      ],
+      "options": ["file"],
       "supportsFile": true,
       "source": "config.Config",
       "sourceFile": "backend/internal/config/config.go",
@@ -365,9 +345,7 @@
       "field": "LogLevel",
       "type": "string",
       "defaultValue": "info",
-      "options": [
-        "toLower"
-      ],
+      "options": ["toLower"],
       "source": "config.Config",
       "sourceFile": "backend/internal/config/config.go",
       "sourceSymbol": "config.Config.LogLevel"
@@ -409,9 +387,7 @@
       "env": "OIDC_CLIENT_ID",
       "field": "OidcClientID",
       "type": "string",
-      "options": [
-        "file"
-      ],
+      "options": ["file"],
       "supportsFile": true,
       "source": "config.Config",
       "sourceFile": "backend/internal/config/config.go",
@@ -421,9 +397,7 @@
       "env": "OIDC_CLIENT_SECRET",
       "field": "OidcClientSecret",
       "type": "string",
-      "options": [
-        "file"
-      ],
+      "options": ["file"],
       "supportsFile": true,
       "source": "config.Config",
       "sourceFile": "backend/internal/config/config.go",


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds documentation for Arcane 1.19.2, focusing on the new non-root container runtime user feature and updated image variant descriptions.

- Introduces a \"Container runtime user\" section in the environment docs explaining `ARCANE_DEFAULT_NONROOT`, `PUID`/`PGID`, and `DOCKER_HOST` socket-group behavior; adds a matching entry for `ARCANE_DEFAULT_NONROOT` in `config.json`.
- Updates `next-images.md` to reflect that the `next` tag now uses a hardened Debian-based runtime (replacing the previous Alpine/distroless description), and documents what `next-static`/`next-distroless` are suited for.
- Expands the GPU setup guide's important callout to clarify that official images do not bundle vendor GPU utilities and how each vendor's monitoring path is provided at runtime.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The docs change is largely accurate, but a contradiction between the generated env table (defaultValue: false) and the prose (official images set it to true) will be visible to users and could cause confusion about the actual out-of-the-box behavior.

The ARCANE_DEFAULT_NONROOT entry in config.json carries defaultValue false, so the auto-generated Environment Variables table will show this setting as off by default. Meanwhile, the new prose in environment.md and installation.md tells users that official images have it set to true and that Arcane drops to a non-root user by default. Users reconciling those two signals are likely to be misled about whether they need to set the variable explicitly in their own deployments.

static/config.json and content/configuration/environment.md need to agree on what the effective default is for users of official images.
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Fwebsite%22%20on%20the%20existing%20branch%20%22docs%2F1.19.2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2F1.19.2%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Astatic%2Fconfig.json%3A78-86%0A**%60defaultValue%60%20contradicts%20documented%20official-image%20behavior**%0A%0A%60config.json%60%20records%20%60%22defaultValue%22%3A%20%22false%22%60%20for%20%60ARCANE_DEFAULT_NONROOT%60%2C%20so%20the%20generated%20%60%3CEnvTable%20%2F%3E%60%20on%20the%20Environment%20Variables%20page%20will%20show%20users%20that%20this%20setting%20defaults%20to%20%60false%60.%20However%2C%20%60environment.md%60%20%28added%20in%20this%20same%20PR%29%20explicitly%20states%20%22Official%20Arcane%20images%20set%20%60ARCANE_DEFAULT_NONROOT%3Dtrue%60%22%2C%20and%20%60installation.md%60%20says%20images%20%22drop%20to%20a%20non-root%20runtime%20user%20by%20default.%22%0A%0AA%20user%20reading%20the%20env%20table%20alongside%20the%20prose%20will%20encounter%20contradictory%20signals%20about%20what%20the%20actual%20default%20behavior%20is.%20If%20official%20images%20hardcode%20%60ARCANE_DEFAULT_NONROOT%3Dtrue%60%20in%20the%20%60Dockerfile%60%20or%20entrypoint%2C%20that%20distinction%20should%20be%20surfaced%20%E2%80%94%20either%20by%20noting%20in%20the%20description%20that%20the%20code%20default%20differs%20from%20the%20image%20default%2C%20or%20by%20adjusting%20%60defaultValue%60%20to%20reflect%20the%20shipped-image%20default%20and%20documenting%20the%20code-level%20fallback%20separately.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Astatic%2Fconfig.json%3A78-86%0A**%60defaultValue%60%20contradicts%20documented%20official-image%20behavior**%0A%0A%60config.json%60%20records%20%60%22defaultValue%22%3A%20%22false%22%60%20for%20%60ARCANE_DEFAULT_NONROOT%60%2C%20so%20the%20generated%20%60%3CEnvTable%20%2F%3E%60%20on%20the%20Environment%20Variables%20page%20will%20show%20users%20that%20this%20setting%20defaults%20to%20%60false%60.%20However%2C%20%60environment.md%60%20%28added%20in%20this%20same%20PR%29%20explicitly%20states%20%22Official%20Arcane%20images%20set%20%60ARCANE_DEFAULT_NONROOT%3Dtrue%60%22%2C%20and%20%60installation.md%60%20says%20images%20%22drop%20to%20a%20non-root%20runtime%20user%20by%20default.%22%0A%0AA%20user%20reading%20the%20env%20table%20alongside%20the%20prose%20will%20encounter%20contradictory%20signals%20about%20what%20the%20actual%20default%20behavior%20is.%20If%20official%20images%20hardcode%20%60ARCANE_DEFAULT_NONROOT%3Dtrue%60%20in%20the%20%60Dockerfile%60%20or%20entrypoint%2C%20that%20distinction%20should%20be%20surfaced%20%E2%80%94%20either%20by%20noting%20in%20the%20description%20that%20the%20code%20default%20differs%20from%20the%20image%20default%2C%20or%20by%20adjusting%20%60defaultValue%60%20to%20reflect%20the%20shipped-image%20default%20and%20documenting%20the%20code-level%20fallback%20separately.%0A%0A&repo=getarcaneapp%2Fwebsite&pr=407&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
static/config.json:78-86
**`defaultValue` contradicts documented official-image behavior**

`config.json` records `"defaultValue": "false"` for `ARCANE_DEFAULT_NONROOT`, so the generated `<EnvTable />` on the Environment Variables page will show users that this setting defaults to `false`. However, `environment.md` (added in this same PR) explicitly states "Official Arcane images set `ARCANE_DEFAULT_NONROOT=true`", and `installation.md` says images "drop to a non-root runtime user by default."

A user reading the env table alongside the prose will encounter contradictory signals about what the actual default behavior is. If official images hardcode `ARCANE_DEFAULT_NONROOT=true` in the `Dockerfile` or entrypoint, that distinction should be surfaced — either by noting in the description that the code default differs from the image default, or by adjusting `defaultValue` to reflect the shipped-image default and documenting the code-level fallback separately.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: docs for 1.19.2"](https://github.com/getarcaneapp/website/commit/fe3917f93babd179b1f8b658c1b747d29347bc3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32453700)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->