### PR TITLE
fix: Fix git sync import example

### DIFF
--- a/content/features/projects.md
+++ b/content/features/projects.md
@@ -166,7 +166,7 @@ To create several syncs at once, paste or upload a JSON array:
     "dockerComposePath": "compose/myproject/compose.yaml",
     "autoSync": true,
     "syncInterval": 5,
-    "enabled": true
+    "syncDirectory": true
   },
   {
     "syncName": "project-name2",
@@ -174,8 +174,7 @@ To create several syncs at once, paste or upload a JSON array:
     "branch": "main",
     "dockerComposePath": "compose/myproject2/compose.yaml",
     "autoSync": true,
-    "syncInterval": 5,
-    "enabled": true
+    "syncInterval": 5
   }
 ]
 ```


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the JSON example in the "Import multiple syncs from JSON" section of the Git sync documentation. The `"enabled": true` field in both example entries has been corrected: replaced with `"syncDirectory": true` in the first entry (aligning it with the "Directory-aware Git sync" feature described just above) and removed entirely from the second entry (showing that `syncDirectory` is optional).

- The first example entry now correctly demonstrates `syncDirectory: true`, matching the feature description above it.
- The second example entry drops the invalid `enabled` field, leaving a cleaner example with no directory sync flag.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only fix; no executable code is changed and the update correctly aligns the example with the described feature.

The change is a small documentation correction replacing an invalid `enabled` field with the correct `syncDirectory` field in one JSON example, and removing the invalid field from a second example. The updated examples are consistent with the surrounding prose about directory-aware Git sync.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Fix git sync import example"](https://github.com/getarcaneapp/website/commit/52e30419f9a7dd031ee7fd3476dde3cb00a2269f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32896905)</sub>

<!-- /greptile_comment -->