### PR TITLE
docs: add Traefik example and TRUSTED_PROXIES guidance for reverse proxies

### DIFF
--- a/content/configuration/websockets-reverse-proxies.md
+++ b/content/configuration/websockets-reverse-proxies.md
@@ -8,7 +8,7 @@ order: 4
 import { Link } from '$lib/components/ui/link/index.js';
 </script>
 
-Arcane uses WebSockets to keep the app updated in real time. If you place Arcane behind a reverse proxy or custom domain, make sure the proxy allows WebSocket connections.
+Arcane uses WebSockets to keep the app updated in real time. If you place Arcane behind a reverse proxy or custom domain, make sure the proxy allows WebSocket connections and forwards the real client IP — Arcane's per-IP login rate limit relies on it to tell clients apart (see [Trust the proxy with `TRUSTED_PROXIES`](#trust-the-proxy-with-trusted_proxies)).
 
 ## Nginx Configuration
 
@@ -59,6 +59,8 @@ The important WebSocket lines are:
 - `proxy_set_header Connection "upgrade";`
 - `proxy_cache_bypass $http_upgrade;`
 
+This config already forwards the client IP via `X-Forwarded-For` and `X-Real-IP`; set `TRUSTED_PROXIES` so Arcane trusts it (see [below](#trust-the-proxy-with-trusted_proxies)).
+
 ## Apache Configuration
 
 If you use Apache 2.4.47 or later, you need `mod_proxy_http` and a `ProxyPassMatch` rule with `upgrade=websocket`:
@@ -82,6 +84,55 @@ Define PORT 3552
   SSLCertificateKeyFile /etc/letsencrypt/live/${HOST}/privkey.pem
 </VirtualHost>
 ```
+
+Apache's `mod_proxy` adds `X-Forwarded-For` automatically; set `TRUSTED_PROXIES` so Arcane trusts it (see [below](#trust-the-proxy-with-trusted_proxies)).
+
+## Traefik Configuration
+
+Traefik proxies WebSocket connections automatically, so no extra middleware is needed for live updates to work. When running Arcane and Traefik with Docker Compose, configure the router and service with labels on the Arcane container:
+
+```yaml
+services:
+  arcane:
+    image: ghcr.io/getarcaneapp/arcane:latest
+    container_name: arcane
+    environment:
+      - APP_URL=https://arcane.example.com
+      - TRUSTED_PROXIES=172.16.0.0/12
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.arcane.rule=Host(`arcane.example.com`)
+      - traefik.http.routers.arcane.entrypoints=websecure
+      - traefik.http.routers.arcane.tls.certresolver=myresolver
+      - traefik.http.services.arcane.loadbalancer.server.port=3552
+```
+
+Notes:
+
+- Set `APP_URL` to the public URL only — do **not** append the internal port (`:3552`). Arcane derives the WebSocket (`wss://`) address from `APP_URL`; an internal port that isn't exposed publicly breaks the WebSocket connection.
+- Set `TRUSTED_PROXIES` to the subnet of the Docker network that Traefik and Arcane share. The example uses `172.16.0.0/12`, which covers Docker's entire default address range and works without further setup; to scope it down to your actual network, see [Trust the proxy with `TRUSTED_PROXIES`](#trust-the-proxy-with-trusted_proxies).
+
+## Trust the proxy with `TRUSTED_PROXIES`
+
+Arcane rate-limits authentication endpoints (login, token refresh, OIDC callback) per client IP. Behind a reverse proxy the direct peer is the proxy, so without extra configuration every request looks like it comes from a single IP — which both weakens brute-force protection and can lock out legitimate users sharing the proxy.
+
+Set the `TRUSTED_PROXIES` environment variable on the Arcane container to the address (or CIDR range) of your reverse proxy. Arcane then reads the real client IP from the `X-Forwarded-For` header for requests coming from those addresses:
+
+```bash
+# Single proxy host
+TRUSTED_PROXIES=10.0.0.5
+
+# Or a CIDR range (e.g. a Docker network)
+TRUSTED_PROXIES=172.16.0.0/12
+```
+
+Docker assigns every user-defined network a subnet from the `172.16.0.0/12` range, which is why the broad example value works anywhere. To scope `TRUSTED_PROXIES` down to your actual network, look up its subnet:
+
+```bash
+docker network inspect <network> --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'
+```
+
+`TRUSTED_PROXIES` accepts a comma-separated list of IPs or CIDR ranges. Only requests whose direct peer is in this list have their forwarded headers trusted, so an untrusted client cannot spoof its IP via `X-Forwarded-For`. See the <Link href="/docs/configuration/environment">Environment Variables</Link> reference for all configuration options.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary

The reverse proxy guide currently only covers Nginx and Apache, and none of
the examples mention `TRUSTED_PROXIES`. This adds a Traefik section and makes
the client-IP requirement explicit.

Two gaps this addresses:

1. **No Traefik example.** Traefik proxies WebSockets automatically, but two
   things still trip people up: appending the internal port to `APP_URL`
   (which breaks the `wss://` connection) and not trusting the proxy for the
   real client IP.
2. **`TRUSTED_PROXIES` is undocumented here.** Behind any reverse proxy, the
   per-IP login rate limit (`/api/auth/login`, `/api/auth/refresh`,
   `/api/oidc/callback`) sees the proxy's IP for every request unless
   `TRUSTED_PROXIES` is set, which both weakens brute-force protection and can
   lock out legitimate users sharing the proxy.

## Changes

- Add a **Traefik** section with a Docker Compose label example (generic TLS
  via `certresolver`), noting that `APP_URL` must not include the internal port
  and that `TRUSTED_PROXIES` should be the shared Docker network subnet.
- Add a dedicated **"Trust the proxy with `TRUSTED_PROXIES`"** section
  explaining why the auth rate limit needs the real client IP, with single-IP
  and CIDR examples, linking to the Environment Variables reference.
- Mention forwarding the real client IP in the intro.

Docs-only change; no code or behavior is affected.

## AI disclosure

Drafted with AI assistance (Kiro, Claude) and reviewed/edited by me before
submission, per the project's AI Usage Policy. The `TRUSTED_PROXIES` behavior
was confirmed against the source (`rate_limit_middleware.go`,
`router_bootstrap.go`) and verified live behind Traefik on my own deployment.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This docs-only PR adds a Traefik reverse-proxy example and a dedicated `TRUSTED_PROXIES` section to the WebSockets configuration guide, addressing two real gaps (no Traefik example, undocumented per-IP rate-limit behaviour behind proxies).

- The `TRUSTED_PROXIES` section correctly explains why auth-rate-limiting breaks behind a proxy and how to fix it, and the Nginx/Apache cross-references are accurate.
- The Traefik Docker Compose snippet is missing a `networks` block; Traefik requires Arcane to share an explicit Docker network with it, so the example won't route traffic as written.
- The guide states that `172.16.0.0/12` "works anywhere" as a `TRUSTED_PROXIES` value, but Docker's default address pools also include `192.168.0.0/16` — on hosts where Docker allocated the Traefik network from that range the CIDR won't cover the proxy, and the rate-limit will silently treat all requests as coming from a single IP again.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The documentation change introduces a factual inaccuracy about Docker network allocation that could leave `TRUSTED_PROXIES` silently misconfigured for some users, defeating the security improvement it is trying to document.

The `172.16.0.0/12` claim is presented as universally reliable, but Docker's default address pools also include `192.168.0.0/16`; users on those subnets would copy a `TRUSTED_PROXIES` value that doesn't cover their Traefik container, causing the rate limiter to collapse all clients onto a single IP. The Traefik example is also missing the `networks` configuration that Traefik requires to actually proxy traffic, so following the snippet verbatim will result in a non-functioning setup.

content/configuration/websockets-reverse-proxies.md — the Traefik section and the Docker subnet explanation both need corrections.
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Fwebsite%22%20on%20the%20existing%20branch%20%22docs-arcane-trusted-proxies%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs-arcane-trusted-proxies%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acontent%2Fconfiguration%2Fwebsockets-reverse-proxies.md%3A129%0AThe%20claim%20that%20%60172.16.0.0%2F12%60%20%22works%20anywhere%22%20is%20incorrect.%20According%20to%20Docker's%20own%20docs%2C%20the%20default%20address%20pools%20include%20%60192.168.0.0%2F16%60%20alongside%20the%20%60172.x.x.x%60%20pools.%20When%20those%20%60172.x.x.x%60%20pools%20are%20exhausted%2C%20Docker%20allocates%20new%20user-defined%20networks%20from%20%60192.168.0.0%2F16%60.%20If%20Traefik%20ends%20up%20on%20a%20%60192.168.x.x%60%20subnet%2C%20%60TRUSTED_PROXIES%3D172.16.0.0%2F12%60%20won't%20cover%20it%2C%20and%20Arcane%20will%20silently%20fall%20back%20to%20trusting%20no%20proxy%20%E2%80%94%20meaning%20the%20rate%20limiter%20sees%20every%20request%20as%20coming%20from%20the%20proxy%20IP%20rather%20than%20the%20real%20client%2C%20which%20is%20exactly%20the%20broken%20behavior%20this%20section%20is%20trying%20to%20prevent.%0A%0A%60%60%60suggestion%0ADocker's%20default%20address%20pools%20cover%20%60172.17.0.0%2F16%60%20through%20%60172.31.x.x%60%20and%20%60192.168.0.0%2F16%60%2C%20so%20%60172.16.0.0%2F12%60%20may%20not%20cover%20your%20Traefik%20container%20if%20Docker%20allocated%20it%20a%20%60192.168.x.x%60%20address.%20The%20only%20reliable%20way%20to%20find%20the%20right%20value%20is%20to%20look%20up%20the%20actual%20subnet%20of%20the%20shared%20network%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acontent%2Fconfiguration%2Fwebsockets-reverse-proxies.md%3A94-108%0A**Traefik%20example%20is%20missing%20the%20shared%20%60networks%60%20stanza**%0A%0AThe%20snippet%20shows%20Traefik%20labels%20but%20omits%20the%20%60networks%60%20block.%20Traefik%20can%20only%20route%20to%20a%20container%20if%20both%20services%20share%20a%20common%20Docker%20network%20%E2%80%94%20without%20an%20explicit%20network%20attachment%20the%20example%20either%20silently%20falls%20back%20to%20the%20default%20bridge%20%28where%20Traefik%20usually%20doesn't%20reside%29%20or%20simply%20fails%20to%20route.%20The%20missing%20configuration%20also%20means%20readers%20have%20no%20concrete%20network%20name%20to%20substitute%20into%20%60docker%20network%20inspect%60%20when%20looking%20up%20the%20subnet%20for%20%60TRUSTED_PROXIES%60.%20A%20minimal%20addition%20would%20be%20a%20%60networks%60%20block%20attaching%20%60arcane%60%20to%20whichever%20network%20Traefik%20watches%20%28e.g.%20a%20pre-created%20%60proxy%60%20network%29%2C%20plus%20a%20note%20that%20%60TRUSTED_PROXIES%60%20should%20be%20that%20network's%20subnet.%0A%0A&repo=getarcaneapp%2Fwebsite&pr=438&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acontent%2Fconfiguration%2Fwebsockets-reverse-proxies.md%3A129%0AThe%20claim%20that%20%60172.16.0.0%2F12%60%20%22works%20anywhere%22%20is%20incorrect.%20According%20to%20Docker's%20own%20docs%2C%20the%20default%20address%20pools%20include%20%60192.168.0.0%2F16%60%20alongside%20the%20%60172.x.x.x%60%20pools.%20When%20those%20%60172.x.x.x%60%20pools%20are%20exhausted%2C%20Docker%20allocates%20new%20user-defined%20networks%20from%20%60192.168.0.0%2F16%60.%20If%20Traefik%20ends%20up%20on%20a%20%60192.168.x.x%60%20subnet%2C%20%60TRUSTED_PROXIES%3D172.16.0.0%2F12%60%20won't%20cover%20it%2C%20and%20Arcane%20will%20silently%20fall%20back%20to%20trusting%20no%20proxy%20%E2%80%94%20meaning%20the%20rate%20limiter%20sees%20every%20request%20as%20coming%20from%20the%20proxy%20IP%20rather%20than%20the%20real%20client%2C%20which%20is%20exactly%20the%20broken%20behavior%20this%20section%20is%20trying%20to%20prevent.%0A%0A%60%60%60suggestion%0ADocker's%20default%20address%20pools%20cover%20%60172.17.0.0%2F16%60%20through%20%60172.31.x.x%60%20and%20%60192.168.0.0%2F16%60%2C%20so%20%60172.16.0.0%2F12%60%20may%20not%20cover%20your%20Traefik%20container%20if%20Docker%20allocated%20it%20a%20%60192.168.x.x%60%20address.%20The%20only%20reliable%20way%20to%20find%20the%20right%20value%20is%20to%20look%20up%20the%20actual%20subnet%20of%20the%20shared%20network%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acontent%2Fconfiguration%2Fwebsockets-reverse-proxies.md%3A94-108%0A**Traefik%20example%20is%20missing%20the%20shared%20%60networks%60%20stanza**%0A%0AThe%20snippet%20shows%20Traefik%20labels%20but%20omits%20the%20%60networks%60%20block.%20Traefik%20can%20only%20route%20to%20a%20container%20if%20both%20services%20share%20a%20common%20Docker%20network%20%E2%80%94%20without%20an%20explicit%20network%20attachment%20the%20example%20either%20silently%20falls%20back%20to%20the%20default%20bridge%20%28where%20Traefik%20usually%20doesn't%20reside%29%20or%20simply%20fails%20to%20route.%20The%20missing%20configuration%20also%20means%20readers%20have%20no%20concrete%20network%20name%20to%20substitute%20into%20%60docker%20network%20inspect%60%20when%20looking%20up%20the%20subnet%20for%20%60TRUSTED_PROXIES%60.%20A%20minimal%20addition%20would%20be%20a%20%60networks%60%20block%20attaching%20%60arcane%60%20to%20whichever%20network%20Traefik%20watches%20%28e.g.%20a%20pre-created%20%60proxy%60%20network%29%2C%20plus%20a%20note%20that%20%60TRUSTED_PROXIES%60%20should%20be%20that%20network's%20subnet.%0A%0A&repo=getarcaneapp%2Fwebsite&pr=438&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/configuration/websockets-reverse-proxies.md:129
The claim that `172.16.0.0/12` "works anywhere" is incorrect. According to Docker's own docs, the default address pools include `192.168.0.0/16` alongside the `172.x.x.x` pools. When those `172.x.x.x` pools are exhausted, Docker allocates new user-defined networks from `192.168.0.0/16`. If Traefik ends up on a `192.168.x.x` subnet, `TRUSTED_PROXIES=172.16.0.0/12` won't cover it, and Arcane will silently fall back to trusting no proxy — meaning the rate limiter sees every request as coming from the proxy IP rather than the real client, which is exactly the broken behavior this section is trying to prevent.

```suggestion
Docker's default address pools cover `172.17.0.0/16` through `172.31.x.x` and `192.168.0.0/16`, so `172.16.0.0/12` may not cover your Traefik container if Docker allocated it a `192.168.x.x` address. The only reliable way to find the right value is to look up the actual subnet of the shared network:
```

### Issue 2 of 2
content/configuration/websockets-reverse-proxies.md:94-108
**Traefik example is missing the shared `networks` stanza**

The snippet shows Traefik labels but omits the `networks` block. Traefik can only route to a container if both services share a common Docker network — without an explicit network attachment the example either silently falls back to the default bridge (where Traefik usually doesn't reside) or simply fails to route. The missing configuration also means readers have no concrete network name to substitute into `docker network inspect` when looking up the subnet for `TRUSTED_PROXIES`. A minimal addition would be a `networks` block attaching `arcane` to whichever network Traefik watches (e.g. a pre-created `proxy` network), plus a note that `TRUSTED_PROXIES` should be that network's subnet.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Traefik example and TRUSTED\_PR..."](https://github.com/getarcaneapp/website/commit/935e558d5ac62d910ed8dd84d61d74bcb0b1ebfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36017237)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->