### PR TITLE
docs: Update auto update settings location in docs

### DIFF
--- a/content/guides/updates.md
+++ b/content/guides/updates.md
@@ -13,11 +13,14 @@ Arcane can poll your registries on a schedule and update containers (or whole Co
 
 ## Enable auto updates
 
-1. Go to **Environments → [your environment] → Settings → Docker**.
-2. Turn on **Image Polling** and pick a schedule (or enter a custom one).
-3. Turn on **Auto Updates**.
-4. Set the run interval (in minutes).
-5. Save.
+1. Go to **Environments** from the left-hand menu.
+2. Select the environment you want to configure, for example **Local Docker**.
+3. Open the **Job Schedules** tab.
+4. Scroll down to the **Updates** section.
+5. Turn on **Image Polling** and pick a schedule, or enter a custom one.
+6. Turn on **Auto Update**.
+7. Set the run interval or schedule.
+8. Save.
 
 > [!NOTE]
 > Very low intervals are clamped to a safer minimum.


### PR DESCRIPTION
Outdated docs. "Docker" tab does not exist. Only "Docker Settings", but auto update and image polling is placed in the Job Schedules tab.

<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the Auto Updates guide to match the current environment scheduling flow.

- Replaces the old Settings → Docker path.
- Points users to the environment Job Schedules tab.
- Updates the image polling and auto update setup steps.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The remaining note is a documentation clarity issue around the schedule field wording.

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Fwebsite%22%20on%20the%20existing%20branch%20%22patch-1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22patch-1%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acontent%2Fguides%2Fupdates.md%3A22%0A**Schedule%20Format%20Remains%20Ambiguous**%0A%0AWhen%20users%20reach%20the%20auto%20update%20control%2C%20%60run%20interval%20or%20schedule%60%20does%20not%20say%20whether%20the%20field%20accepts%20minutes%20or%20a%20cron%20schedule.%20The%20related%20configuration%20uses%20a%20cron-style%20%60autoUpdateInterval%60%2C%20so%20a%20user%20can%20enter%20a%20minute%20value%20like%20%6060%60%20and%20fail%20to%20save%20or%20misconfigure%20the%20job.%0A%0A%60%60%60suggestion%0A7.%20Set%20the%20run%20schedule%20using%20the%20format%20shown%20in%20the%20field.%0A%60%60%60%0A%0A&repo=getarcaneapp%2Fwebsite&pr=462&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acontent%2Fguides%2Fupdates.md%3A22%0A**Schedule%20Format%20Remains%20Ambiguous**%0A%0AWhen%20users%20reach%20the%20auto%20update%20control%2C%20%60run%20interval%20or%20schedule%60%20does%20not%20say%20whether%20the%20field%20accepts%20minutes%20or%20a%20cron%20schedule.%20The%20related%20configuration%20uses%20a%20cron-style%20%60autoUpdateInterval%60%2C%20so%20a%20user%20can%20enter%20a%20minute%20value%20like%20%6060%60%20and%20fail%20to%20save%20or%20misconfigure%20the%20job.%0A%0A%60%60%60suggestion%0A7.%20Set%20the%20run%20schedule%20using%20the%20format%20shown%20in%20the%20field.%0A%60%60%60%0A%0A&repo=getarcaneapp%2Fwebsite&pr=462&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/guides/updates.md:22
**Schedule Format Remains Ambiguous**

When users reach the auto update control, `run interval or schedule` does not say whether the field accepts minutes or a cron schedule. The related configuration uses a cron-style `autoUpdateInterval`, so a user can enter a minute value like `60` and fail to save or misconfigure the job.

```suggestion
7. Set the run schedule using the format shown in the field.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update updates.md"](https://github.com/getarcaneapp/website/commit/0454e3845b5759ae1234c2cc17a145a11c4e6c27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40352682)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/ofkm/-/custom-context?memory=2e3f3c6f-4c88-4dcf-b9fa-85cac1da67f7))

<!-- /greptile_comment -->