### PR TITLE
Next Version

### DIFF
--- a/content/features/environments.md
+++ b/content/features/environments.md
@@ -11,6 +11,8 @@ import ScreenshotFrame from '$lib/components/screenshot-frame.svelte';
 
 A **Remote Environment** is a Docker host outside the Arcane Manager that you want to manage from the same UI. You create the environment in Arcane, copy the generated agent settings, and run the **Arcane Agent** on the remote host. The Agent needs Docker access — typically via `/var/run/docker.sock`.
 
+If that host is also a Docker Swarm node, the same Agent can remain a visible Remote Environment and provide verified node coverage in **Swarm → Nodes**. Arcane reuses the environment's existing token; attaching it to a node does not rotate or replace the token.
+
 <ScreenshotFrame
   src="/img/screenshots/environments-page.jpeg"
   alt="Remote environments page in Arcane"
@@ -34,6 +36,22 @@ Connection mode is *who connects to whom*. Transport mode is *how the live chann
 - **`EDGE_TRANSPORT=poll`** — check in periodically instead of holding a tunnel open. The first action on an idle environment can take a moment while the connection wakes up.
 
 Generated agent snippets default to `EDGE_TRANSPORT=poll`.
+
+The canonical container image is `ghcr.io/getarcaneapp/agent`. The older `ghcr.io/getarcaneapp/arcane-headless` name remains a supported release alias for existing installations.
+
+## Use an environment with Swarm
+
+With an active Swarm manager selected, you can start the same **Easy Join** workflow from:
+
+- **Swarm → Cluster** to join one or more Remote Environments.
+- An eligible environment's detail page to join that environment.
+- An eligible environment's row menu on the **Environments** page.
+
+Select a worker or manager role, an availability mode, and any optional per-environment listen, advertise, or data-path address. Arcane discovers a reachable manager address and retrieves the correct join token internally; neither needs to be copied into the Easy Join dialog or returned in its result.
+
+The single-environment actions appear only when the Remote Environment is enabled, online, not already bound to a Swarm node, and you have the required permissions. The selected environment is always the Swarm manager, so it cannot also be an Easy Join target.
+
+After a verified join, the environment is bound to its Swarm node. From the node's Agent dialog you can switch to the environment's Containers, Images, Volumes, or Networks pages when permitted.
 
 ## Status meanings
 

--- a/content/features/swarm-cluster.md
+++ b/content/features/swarm-cluster.md
@@ -34,6 +34,33 @@ Use this when the environment should join an existing cluster as a manager or wo
 3. Enter manager addresses, the join token, and any optional listen/advertise addresses.
 4. Confirm.
 
+## Easy Join Remote Environments
+
+When the selected environment is an initialized Swarm manager, use **Easy Join** to add existing Remote Environments without copying manager addresses or join tokens.
+
+You can start Easy Join in three places:
+
+- **Swarm → Cluster → Easy Join** for one or more targets.
+- An eligible Remote Environment's detail page for that environment.
+- An eligible Remote Environment's row menu on the **Environments** page.
+
+For a multi-environment join:
+
+1. Select each target environment.
+2. Choose **worker** or **manager** and an availability mode.
+3. Optionally set listen, advertise, or data-path addresses per target.
+4. Confirm.
+
+Arcane discovers a reachable address from the selected manager's cluster state and retrieves worker and manager tokens internally. Easy Join responses never expose the tokens. Manager targets are processed sequentially and workers use bounded concurrency. Each target has an independent result, so one failure does not undo successful joins.
+
+- Already in this cluster: verified and bound without rejoining.
+- Active in another cluster: rejected without forcing a leave.
+- Joined but not verified before timeout: shown as **joined, verification pending**. Nodes-page reconciliation completes the binding later.
+
+Easy Join requires `swarm:unlock` and `swarm:nodes` on the selected manager plus `swarm:join` on every target.
+
+Environment detail and row-menu actions are shown only for enabled, online Remote Environments that are eligible to join the active selected manager and are not already bound to one of its nodes.
+
 ## Leave a cluster
 
 Click **Leave** when a node should no longer be part of the Swarm. You can force the leave when needed. Arcane refreshes environment state after the operation completes.
@@ -65,3 +92,4 @@ The Cluster page can update the live Swarm spec through the UI. This is for adva
 - Swarm actions apply to the currently selected environment.
 - Full cluster management requires a **Swarm manager** environment.
 - Administrative actions require admin access in Arcane.
+- The Arcane Manager's own Docker node receives local Agent coverage automatically.

--- a/content/features/swarm-nodes-agents.md
+++ b/content/features/swarm-nodes-agents.md
@@ -37,7 +37,9 @@ A Swarm manager exposes cluster-level resources, but it doesn't act as the local
 - generating a node-specific deploy command
 - confirming the connected agent is running on the expected Swarm node
 
-The agent model is similar to <Link href="/docs/features/environments">Remote Environments</Link>, but in the Swarm workspace Arcane tracks it per node — for coverage and identity verification, not as a merged cluster-wide inventory.
+The same direct or edge Agent can serve two roles at once: it remains a visible <Link href="/docs/features/environments">Remote Environment</Link> and provides verified coverage for the Swarm node where it runs. Arcane automatically covers the Manager's own local Docker node, so that node does not need a second Agent.
+
+Legacy dedicated hidden node Agents remain supported for compatibility. New node-agent deployments create visible Remote Environments so the same Agent can provide both environment management and Swarm-node coverage.
 
 ## Agent statuses
 
@@ -48,19 +50,42 @@ Each node shows one of:
 - **offline** — the agent exists but isn't currently connected.
 - **connected** — the agent is connected and verified against the node.
 - **mismatched** — an agent connected, but its node identity doesn't match the row you deployed it for.
+- **ambiguous** — more than one visible environment reported the same node identity, so Arcane did not choose one automatically.
 
-## Deploy a node agent
+The Nodes page reconciles visible Remote Environments when you have the `swarm:nodes` permission. Unique verified matches are attached automatically. Conflicts fail closed: select the intended environment in the Agent dialog.
+
+## Cover a node
+
+Open a node's Agent dialog to see one of three coverage types:
+
+- **Local manager** — automatic coverage from the Arcane Manager's Docker socket.
+- **Remote Environment** — a visible direct or edge environment verified against this node. Its existing Agent token is preserved.
+- **Dedicated node Agent** — a hidden registration created only for node coverage.
+
+When a visible environment covers the node, the dialog links to its **Containers**, **Images**, **Volumes**, and **Networks** pages when your permissions allow those pages.
+
+### Create coverage for a node
 
 1. Open **Swarm → Nodes**.
 2. Find the target node.
-3. Click **Deploy Agent**.
-4. Arcane shows a dialog with the current status, the (hidden) Arcane environment ID for this node, a `docker run` command, and a Compose snippet.
+3. Open the Agent dialog and choose **Create environment**.
+4. Arcane creates one visible Edge Remote Environment and shows a `docker run` command and Compose snippet using `ghcr.io/getarcaneapp/agent`.
 5. Run one of those on the target node.
 6. Click **Refresh Status** in Arcane.
 
-When the agent connects and reports the expected node identity, the status flips to **connected**.
+When the Agent connects and reports the expected node identity, the environment is verified, bound to the node, and shown as **connected**. Its token is the Remote Environment's normal Agent token; the binding does not replace or rotate it.
 
-The dialog also has **Regenerate API Key**. Use this if the previous token was lost, the node was rebuilt, or you need to invalidate an older install command.
+If you already created and connected a Remote Environment for the host, use **Easy Join** to add it to the cluster. Reconciliation attaches a unique identity match automatically. When multiple environments report the same node, open the Agent dialog and choose the intended verified candidate.
+
+### Legacy dedicated registrations
+
+Existing hidden dedicated node Agents continue to provide coverage. Their Agent dialog labels them as a **Legacy dedicated registration** and lets you show the deployment, regenerate its API key, or remove the registration.
+
+Removing a legacy registration deletes its hidden environment and API key. Replacing one with a verified visible Remote Environment requires explicit confirmation and removes the obsolete hidden registration. `ghcr.io/getarcaneapp/arcane-headless` remains a supported release alias for existing deployments.
+
+### Change a visible binding
+
+Detaching a visible Remote Environment removes only its Swarm-node binding. It does not delete the environment or change its Agent token. Rebinding to another verified environment requires explicit confirmation; Arcane never moves conflicting bindings as a side effect of refreshing the Nodes page.
 
 ## Troubleshooting
 
@@ -70,8 +95,10 @@ The dialog also has **Regenerate API Key**. Use this if the previous token was l
 - the manager URL is reachable from that node
 - the token is still current
 
-**Showing `mismatched`.** An agent connected but its identity doesn't match the row. Regenerate the API key and redeploy on the correct node.
+**Showing `mismatched`.** The bound environment reports a different node ID. Detach it or explicitly rebind the correct environment; Arcane will not silently move a conflicting binding.
+
+**Showing `ambiguous`.** Open the Agent dialog and select the intended verified Remote Environment.
 
 ## Current limitations
 
-Node-agent coverage doesn't merge every node's local containers, images, volumes, and networks into one cluster-wide view inside Arcane. Cluster-level Swarm resources come from the manager; per-node coverage is tracked separately.
+Node-agent coverage doesn't merge every node's local containers, images, volumes, and networks into one cluster-wide list. Cluster-level Swarm resources come from the manager; node-local links switch to the bound Remote Environment's existing resource pages.

--- a/content/features/swarm.md
+++ b/content/features/swarm.md
@@ -21,7 +21,7 @@ Arcane reads cluster data directly from the Swarm manager:
 
 That means the Stacks list is **live** — not built from a database, and not reconstructed from saved Compose files. A stack created outside Arcane shows up as long as the manager can see its services.
 
-For node-level coverage, Arcane also supports per-node agents. They handle node identity verification and per-node operations; they don't merge every node's local resources into one cluster-wide inventory.
+For node-level coverage, Arcane verifies the same Agents used by visible Remote Environments. The Manager's local Docker node is covered automatically, and dedicated hidden Agents remain available as a fallback.
 
 ## Permissions and modes
 
@@ -43,7 +43,7 @@ For node-level coverage, Arcane also supports per-node agents. They handle node 
 1. Pick the environment.
 2. Open **Swarm → Cluster** and confirm the environment is in the expected Swarm.
 3. Check **Nodes** — managers, workers, and availability.
-4. Deploy Arcane node agents to the nodes you want covered.
+4. Use **Easy Join** from the Cluster page, an environment detail page, or an environment row menu. Arcane handles manager addressing and join tokens, then binds unique verified Agent identities automatically.
 5. Create the **Configs** and **Secrets** your app needs.
 6. Deploy from **Stacks**.
 7. Use **Services** and **Tasks** to inspect rollout health and logs.
@@ -60,5 +60,7 @@ For node-level coverage, Arcane also supports per-node agents. They handle node 
 - the token is still current
 
 **A node agent shows `mismatched`.** An agent connected, but the reported node identity doesn't match the row you deployed it for. Regenerate the API key and redeploy on the right node.
+
+**A node agent shows `ambiguous`.** Multiple visible environments reported the node identity. Open the node's Agent dialog and select the intended environment.
 
 **Services or stacks visible, but per-node coverage is incomplete.** Expected if some nodes don't have Arcane agents connected. Cluster-level resources come from the Swarm manager; per-node coverage is tracked separately.


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer** Greptiles Reviews use AI, make sure to check over its work.

To better help train Greptile on our codebase, if the comment is useful and valid **Like** the comment, if its not helpful or invalid **Dislike**

To have Greptile Re-Review the changes, mention `greptileai`.

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the Swarm and Remote Environments docs for the new node coverage flow.

- Adds Easy Join guidance for Remote Environments and Swarm clusters.
- Documents visible Remote Environment bindings for Swarm node coverage.
- Describes local manager coverage, ambiguous matches, and legacy dedicated registrations.
- Updates the canonical agent image references.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after a small documentation consistency fix.

Only one non-blocking docs consistency issue was found. The rest of the changed content is coherent and limited to documentation.

`content/features/swarm.md` needs its mismatched-agent troubleshooting guidance updated.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The build completed and produced the build directory.
- All four changed routes returned HTTP 200 with non-empty main text in the route status checks.
- A Playwright run captured a video of the after-change UI and its poster frame.
- After-change UI screenshots were captured for four routes to validate the UI render.

<a href="https://app.greptile.com/trex/runs/14328441/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22getarcaneapp%2Fwebsite%22%20on%20the%20existing%20branch%20%22next_version%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22next_version%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acontent%2Ffeatures%2Fswarm.md%3A62%0A**Update%20mismatched%20guidance**%0AThe%20updated%20node-agent%20model%20no%20longer%20uses%20%60Regenerate%20API%20Key%60%20for%20visible%20Remote%20Environment%20bindings%3A%20%60swarm-nodes-agents.md%60%20now%20says%20mismatches%20should%20be%20fixed%20by%20detaching%20or%20explicitly%20rebinding%20the%20correct%20environment%2C%20and%20token%20rotation%20is%20only%20described%20for%20legacy%20dedicated%20registrations.%20Leaving%20this%20troubleshooting%20entry%20as-is%20sends%20users%20down%20the%20wrong%20remediation%20path%20for%20the%20new%20default%20flow.%0A%0A&repo=getarcaneapp%2Fwebsite&pr=473&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acontent%2Ffeatures%2Fswarm.md%3A62%0A**Update%20mismatched%20guidance**%0AThe%20updated%20node-agent%20model%20no%20longer%20uses%20%60Regenerate%20API%20Key%60%20for%20visible%20Remote%20Environment%20bindings%3A%20%60swarm-nodes-agents.md%60%20now%20says%20mismatches%20should%20be%20fixed%20by%20detaching%20or%20explicitly%20rebinding%20the%20correct%20environment%2C%20and%20token%20rotation%20is%20only%20described%20for%20legacy%20dedicated%20registrations.%20Leaving%20this%20troubleshooting%20entry%20as-is%20sends%20users%20down%20the%20wrong%20remediation%20path%20for%20the%20new%20default%20flow.%0A%0A&repo=getarcaneapp%2Fwebsite&pr=473&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/features/swarm.md:62
**Update mismatched guidance**
The updated node-agent model no longer uses `Regenerate API Key` for visible Remote Environment bindings: `swarm-nodes-agents.md` now says mismatches should be fixed by detaching or explicitly rebinding the correct environment, and token rotation is only described for legacy dedicated registrations. Leaving this troubleshooting entry as-is sends users down the wrong remediation path for the new default flow.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Next Version"](https://github.com/getarcaneapp/website/commit/d2d1becd3968506df2151452ff72546653426bf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44007544)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->